### PR TITLE
i10: add basic travis-ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/pom.xml
+++ b/pom.xml
@@ -46,4 +46,9 @@
 
   </dependencies>
   <url>https://github.com/IBM-Bluemix/cf-deployment-tracker-client-java</url>
+
+  <build>
+    <defaultGoal>package</defaultGoal>
+  </build>
+
 </project>


### PR DESCRIPTION
i10 delivery part 1: 
* add basic Travis-CI configuration file
* set _package_ as default maven build goal